### PR TITLE
👷 ci(server): add lint server code to github CI

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,0 +1,46 @@
+name: Server linting, testing, building
+run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  pipeline:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Starting Node.JS ${{matrix.node-version}}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{matrix.node-version}}
+
+      - name: install yarn
+        run: npm install --global yarn
+
+      - name: install modules
+        working-directory: ./server
+        run: yarn install --frozen-lockfile
+
+      #      - name: testing
+      #        run: yarn test
+      #        if: always()
+
+      - name: linting ESLint
+        working-directory: ./server
+        run: yarn lint
+        if: always()
+
+      - name: format Prettier
+        working-directory: ./server
+        run: yarn prettier
+        if: always()

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -5,13 +5,13 @@ on:
   push:
     branches:
       - main
-      - dev
+      - develop
     paths:
       - "server/**"
   pull_request:
     branches:
       - main
-      - dev
+      - develop
     paths:
       - "server/**"
 

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -24,9 +24,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Starting Node.JS ${{matrix.node-version}}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{matrix.node-version}}
+
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v2.1.6
+        with:
+            path: ./server/node_modules
+            key: ${{ runner.os }}-yarn-${{ hashFiles('./server/yarn.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-yarn-
 
       - name: install yarn
         run: npm install --global yarn
@@ -37,14 +45,11 @@ jobs:
 
       #      - name: testing
       #        run: yarn test
-      #        if: always()
 
       - name: linting ESLint
         working-directory: ./server
         run: yarn lint
-        if: always()
 
       - name: format Prettier
         working-directory: ./server
         run: yarn prettier
-        if: always()

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -6,10 +6,14 @@ on:
     branches:
       - main
       - dev
+    paths:
+      - "server/**"
   pull_request:
     branches:
       - main
       - dev
+    paths:
+      - "server/**"
 
 jobs:
   pipeline:


### PR DESCRIPTION
Добавил прогонку линтеров на бекенд коде чтоб соблюдать чистоту. Теперь будут гоняться GitHub actions.
Гоняются они только при пуше в мейн и дев и при пулл реквестах в дев и мейн.
Чтоб заработало нужно довезти в мейн